### PR TITLE
SEO-204026-Image-Alt-Missing-jsp-Hotfix

### DIFF
--- a/jsp/Getting-Started.md
+++ b/jsp/Getting-Started.md
@@ -19,7 +19,7 @@ documentation: ug
 4.	JSP SampleBrowser will be launched under the default port 8080 (localhost: 8080/SampleBrowser/index.jsp).
 5.	Browse product samples using the Sample Browser.
 
-![](Getting-Started_images/Getteing-Started_img5.PNG)
+![Getting Started for js.](Getting-Started_images/Getteing-Started_img5.PNG)
 
 ### Steps to utilize Essential JS for JSP components in Dynamic web application with Eclipse environment
 
@@ -28,14 +28,14 @@ To use Essential JS for JSP in eclipse environment, follow the steps below:
 
 1. Eclipse IDE with Apache Tomcat 7 configured 
 
-  ![](Getting-Started_images/Getteing-Started_img1.png)
+  ![Essential JS for JSP in eclipse environment.](Getting-Started_images/Getteing-Started_img1.png)
 
 
 2. Create a Dynamic web application in eclipse
 
    *	Choose File > New > Project....
    *	In the upcoming wizard choose Web > Dynamic Web Project.
-   ![](Getting-Started_images/Getteing-Started_img2.PNG)
+   ![Create a Dynamic web application in eclipse.](Getting-Started_images/Getteing-Started_img2.PNG)
 
   And create a new Dynamic web project in eclipse.
 
@@ -61,7 +61,7 @@ To use Essential JS for JSP in eclipse environment, follow the steps below:
 
     {% endhighlight %}
 
-    ![](Getting-Started_images/Getteing-Started_img3.PNG)
+    ![create a new Dynamic web project in eclipse.](Getting-Started_images/Getteing-Started_img3.PNG)
 
 5. Now add the Essential JS for JSP source package from \SampleBrowser\WEB-INF\lib\syncfusion-taglib-[version].jar to your project's /WebContent/WEB-INF/lib folder.
 
@@ -100,7 +100,7 @@ To use Essential JS for JSP in eclipse environment, follow the steps below:
 10. Finally, right-click your project’s in the Eclipse Project Explorer.
 
    * Select Run As > Run on server.
-  ![](Getting-Started_images/Getteing-Started_img4.PNG)
+  ![the Eclipse Project Explorer.](Getting-Started_images/Getteing-Started_img4.PNG)
 
 
 

--- a/jsp/Treeview/Getting-Started.md
+++ b/jsp/Treeview/Getting-Started.md
@@ -90,7 +90,7 @@ Create the JSP file and add the below given code to render **TreeView** control.
 
 You can execute the above code example to display the **TreeView** control.
 
-![](Getting Started-images/TreeView_image1.png) 
+![Create a TreeView in JSP.](Getting Started-images/TreeView_image1.png) 
 
 ## Data Binding
 
@@ -164,4 +164,4 @@ Refer the below code to render TreeView with local datasource.
 
 Run the above code to get the following output.
 
-![](Getting Started-images/TreeView_image2.png) 
+![The data for TreeView.](Getting Started-images/TreeView_image2.png) 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204388|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha